### PR TITLE
Backport 844efe1 to 11.1.x

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -418,7 +418,7 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
         // Do we have a target node yet? If not, select randomly
         Task<NodeAddress> nodeAddressTask = nodeAddress != null ? Task.fromValue(nodeAddress) : selectNode(interfaceClass.getName());
 
-        return nodeAddressTask.thenApply((selectedNodeAddress) -> {
+        return nodeAddressTask.thenCompose((selectedNodeAddress) -> {
             // Push our selection to the distributed cache (if possible)
             NodeAddress otherNodeAddress = distributedDirectory.putIfAbsent(remoteKey, selectedNodeAddress);
 
@@ -430,7 +430,10 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
 
             localAddressCache.put(actorReference, selectedNodeAddress);
 
-            return selectedNodeAddress;
+            return Task.fromValue(selectedNodeAddress).whenCompleteAsync((r, e) ->
+            {
+                // place holder, just to ensure the completion happens in another thread
+            }, stage.getExecutionPool());
         });
     }
 

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -387,7 +387,7 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
 
         // Get the existing activation from the distributed cache (if any)
         NodeAddress nodeAddress = distributedDirectory.get(remoteKey);
-        // Ensure we're running in the correct thread
+        // Ensure we're running on the correct thread
         await(Task.runAsync(() -> {}, stage.getExecutionPool()));
 
         if (nodeAddress != null)
@@ -403,7 +403,7 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
             {
                 // Target node is now dead, remove this activation from distributed cache
                 distributedDirectory.remove(remoteKey, nodeAddress);
-                // Ensure we're running in the correct thread
+                // Ensure we're running on the correct thread
                 await(Task.runAsync(() -> {}, stage.getExecutionPool()));
             }
         }

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -387,8 +387,6 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
 
         // Get the existing activation from the distributed cache (if any)
         NodeAddress nodeAddress = distributedDirectory.get(remoteKey);
-        // Ensure we're running on the correct thread
-        await(Task.runAsync(() -> {}, stage.getExecutionPool()));
 
         if (nodeAddress != null)
         {
@@ -403,8 +401,6 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
             {
                 // Target node is now dead, remove this activation from distributed cache
                 distributedDirectory.remove(remoteKey, nodeAddress);
-                // Ensure we're running on the correct thread
-                await(Task.runAsync(() -> {}, stage.getExecutionPool()));
             }
         }
         nodeAddress = null;

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -395,7 +395,10 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
             {
                 // Cache locally
                 localAddressCache.put(actorReference, nodeAddress);
-                return Task.fromValue(nodeAddress);
+                return Task.fromValue(nodeAddress).whenCompleteAsync((r, e) ->
+                {
+                    // place holder, just to ensure the completion happens in another thread
+                }, stage.getExecutionPool());
             }
             else
             {

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -387,6 +387,9 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
 
         // Get the existing activation from the distributed cache (if any)
         NodeAddress nodeAddress = distributedDirectory.get(remoteKey);
+        // Ensure we're running in the correct thread
+        await(Task.runAsync(() -> {}, stage.getExecutionPool()));
+
         if (nodeAddress != null)
         {
             // Target node still valid?
@@ -400,6 +403,8 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
             {
                 // Target node is now dead, remove this activation from distributed cache
                 distributedDirectory.remove(remoteKey, nodeAddress);
+                // Ensure we're running in the correct thread
+                await(Task.runAsync(() -> {}, stage.getExecutionPool()));
             }
         }
         nodeAddress = null;

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -64,6 +64,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.ea.async.Async.await;
@@ -395,10 +396,8 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
             {
                 // Cache locally
                 localAddressCache.put(actorReference, nodeAddress);
-                return Task.fromValue(nodeAddress).whenCompleteAsync((r, e) ->
-                {
-                    // place holder, just to ensure the completion happens in another thread
-                }, stage.getExecutionPool());
+                // Ensure completion happens on the correct thread
+                return Task.fromValue(nodeAddress).thenApplyAsync(r -> r, stage.getExecutionPool());
             }
             else
             {


### PR DESCRIPTION
This is an attempt to backport https://github.com/orbit-legacy/orbit1/commit/844efe104d526194fb15f93bcc295eadf004fd4c to the 11.1.x line.

The code has changed quite a bit since then. We're seeing code running on Redisson Netty threads when it should be on Orbit threads.